### PR TITLE
Send events one call after renaming file

### DIFF
--- a/send.php
+++ b/send.php
@@ -29,64 +29,73 @@ if ($file[0] != '/') $file = __DIR__ . "/" . $file;
 
 $dir = dirname($file);
 $old = $file;
-$file = $dir . '/analytics-' . rand() . '.log';
 
-if(!file_exists($old)) {
-  print("file: $old does not exist");
-  exit(0);
+$newFileName = 'analytics-' . rand() . '.log';
+$newFile = $dir . '/' . $newFileName;
+
+if(file_exists($old)) {
+    if (!rename($old, $newFile)) {
+        print("error renaming from $old to $newFile\n");
+        exit(1);
+    }
 }
 
-if (!rename($old, $file)) {
-  print("error renaming from $old to $file\n");
-  exit(1);
+foreach(scandir($dir) as $file) {
+    if (substr($file, 0, strlen('analytics-')) !== 'analytics-') {
+        continue;
+    }
+    if ($file === $newFileName) {
+        continue;
+    }
+
+    /**
+    * File contents.
+    */
+
+    $contents = file_get_contents($file);
+    $lines = explode("\n", $contents);
+
+    /**
+    * Initialize the client.
+    */
+
+    Segment::init($args["secret"], array(
+        "debug" => true,
+        "error_handler" => function($code, $msg){
+            print("$code: $msg\n");
+            exit(1);
+        }
+    ));
+
+    /**
+    * Payloads
+    */
+
+    $total = 0;
+    $successful = 0;
+    foreach ($lines as $line) {
+        if (!trim($line)) continue;
+        $payload = json_decode($line, true);
+        $dt = new DateTime($payload["timestamp"]);
+        $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
+        $payload["timestamp"] = $ts;
+        $type = $payload["type"];
+        $ret = call_user_func_array(array("Segment", $type), array($payload));
+        if ($ret) $successful++;
+        $total++;
+        if ($total % 100 === 0) Segment::flush();
+    }
+
+    Segment::flush();
+    unlink($file);
+
+    print("sent $successful from $total requests successfully");
 }
-
-/**
- * File contents.
- */
-
-$contents = file_get_contents($file);
-$lines = explode("\n", $contents);
-
-/**
- * Initialize the client.
- */
-
-Segment::init($args["secret"], array(
-  "debug" => true,
-  "error_handler" => function($code, $msg){
-    print("$code: $msg\n");
-    exit(1);
-  }
-));
-
-/**
- * Payloads
- */
-
-$total = 0;
-$successful = 0;
-foreach ($lines as $line) {
-  if (!trim($line)) continue;
-  $payload = json_decode($line, true);
-  $dt = new DateTime($payload["timestamp"]);
-  $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
-  $payload["timestamp"] = $ts;
-  $type = $payload["type"];
-  $ret = call_user_func_array(array("Segment", $type), array($payload));
-  if ($ret) $successful++;
-  $total++;
-  if ($total % 100 === 0) Segment::flush();
-}
-
-Segment::flush();
-unlink($file);
 
 /**
  * Sent
  */
 
-print("sent $successful from $total requests successfully");
 exit(0);
 
 /**


### PR DESCRIPTION
*Will not actually be merging this, just looking for code review before I PR it for Segment.*

This solves a race condition where the client can write to the file after the sender has already renamed it and read its contents. This would mean that events can (and do) disappear with the `unlink` call. In our production environment we lost over 30 events in an hour.

Graphical explanation:
```
  client │ open   write(1)   write(2)
         │ ↓      ↓          ↓
   $file ├──────────────────────────────...───...
         │   ↑        ↑                     ↑
send.php │   rename   file_get_contents()   unlink()
```

`write(1)` is fine, since the file descriptor will persist after the rename. `write(2)` is will be lost. The solution here is decreasing the possibility of this happening by assuming that clients don't live longer than the `save.php` cron interval (a minute, in our case):

1. Rename the current file.
2. Read the directory for files _other than_ the just-renamed file, parse those events, remove them.

This means that the current file is left, renamed, for the duration of the cron interval. So basically a grace period of a minute. This is the most effective way I could think of of reducing the issue without changing the client.